### PR TITLE
Vetion plugin bugfixes'

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/vetion/VetionOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/vetion/VetionOverlay.java
@@ -63,7 +63,7 @@ public class VetionOverlay extends Overlay{
             if (localPos != null)
             {
                 Point position = Perspective.localToCanvas(client, localPos, client.getPlane(),
-                        actor.getLogicalHeight() + 16);
+                        actor.getLogicalHeight() + 96);
                 if (position != null)
                 {
                     position = new Point(position.getX(), position.getY());
@@ -80,6 +80,10 @@ public class VetionOverlay extends Overlay{
                             : 1));
 
                     progressPie.render(graphics);
+                    if (1 - duration.compareTo(MAX_TIME) < 0)
+                    {
+                        plugin.getVetions().remove(actor);
+                    }
                 }
             }
         });


### PR DESCRIPTION
Fixes an issue where Vet'ion's earthquake timer would persist on the map even after it was empty. Also raises the timer a bit vertically so it's not obscured by Vet'ion's healthbar.